### PR TITLE
add physics overrides to armor

### DIFF
--- a/3d_armor/armor.lua
+++ b/3d_armor/armor.lua
@@ -243,7 +243,7 @@ minetest.register_on_joinplayer(function(player)
 			armor.textures[name].skin = "player_"..name..".png"
 		end
 	end
-	minetest.after(10, function(player)
+	minetest.after(1, function(player)
 		armor:set_player_armor(player)
 	end, player)
 end)


### PR DESCRIPTION
adds physics overrides to groups, for example in register_tool:

groups = {armor_feet=10, armor_heal=0, armor_use=100, physics_jump=.58},

this pull request adds physics_jump, physics_speed, and physics_gravity to groups
