### PR TITLE
Put aromr drops into a single loop, fix #22

### DIFF
--- a/3d_armor/armor.lua
+++ b/3d_armor/armor.lua
@@ -497,29 +497,27 @@ if ARMOR_DROP == true or ARMOR_DESTROY == true then
 						local owner = meta:get_string("owner")
 						local inv = meta:get_inventory()
 						if name == owner then
-							for i, stack in ipairs(drop) do
+							for _,stack in ipairs(drop) do
 								if inv:room_for_item("main", stack) then
 									inv:add_item("main", stack)
-									table.remove(drop, i)
+								else
+									local obj = minetest.add_item(pos, stack)
+									if obj then
+										local x = math.random(1, 5)
+										if math.random(1,2) == 1 then
+											x = -x
+										end
+										local z = math.random(1, 5)
+										if math.random(1,2) == 1 then
+											z = -z
+										end
+										obj:setvelocity({x=1/x, y=obj:getvelocity().y, z=1/z})
+									end
 								end
 							end
 						end
 					end
 				end)
-			end
-			for _,stack in ipairs(drop) do
-				local obj = minetest.add_item(pos, stack)
-				if obj then
-					local x = math.random(1, 5)
-					if math.random(1,2) == 1 then
-						x = -x
-					end
-					local z = math.random(1, 5)
-					if math.random(1,2) == 1 then
-						z = -z
-					end
-					obj:setvelocity({x=1/x, y=obj:getvelocity().y, z=1/z})
-				end
 			end
 		end
 	end)


### PR DESCRIPTION
It appears the armor drop table was not getting properly stored upon removing items from it, causing armor duplication on a player's death.
This change should fix that, by *only* running minetest.add_item if there is no room in the bones' inventory.
I've also simplified it into one 'for' loop instead of two, so it may be marginally faster (not that there was a speed problem anyway).
