### PR TITLE
dtime glitches

### DIFF
--- a/3d_armor/armor.lua
+++ b/3d_armor/armor.lua
@@ -236,13 +236,13 @@ armor.set_player_armor = function(self, player)
 	self:update_player_visuals(player)
 end
 
-armor.update_armor = function(self, player, dtime)
+armor.update_armor = function(self, player)
 	local name, player_inv, armor_inv, pos = armor:get_valid_player(player, "[update_armor]")
 	if not name then
 		return
 	end
 	local hp = player:get_hp() or 0
-	if ARMOR_FIRE_PROTECT == true and dtime then
+	if ARMOR_FIRE_PROTECT == true then
 		pos.y = pos.y + 1.4 -- head level
 		local node_head = minetest.get_node(pos).name
 		pos.y = pos.y - 1.2 -- feet level
@@ -252,7 +252,7 @@ armor.update_armor = function(self, player, dtime)
 			-- check for fire protection, if not enough then get hurt
 			if row[1] == node_head or row[1] == node_feet then
 				if hp > 0 and armor.def[name].fire < row[2] then
-					hp = hp - row[3] * dtime
+					hp = hp - row[3] * ARMOR_UPDATE_TIME
 					player:set_hp(hp)
 					break
 				end


### PR DESCRIPTION
sometimes dtime isn't registering when armor.update_armor is called and so it never checks for fire resistance on armor meaning cactus is fireproof if ethereal mod is found...  we cant have that :)  replaced dtime with ARMOR_UPDATE_TIME and it works fine :)