### PR TITLE
Prevent admin armor from being dropped

### DIFF
--- a/3d_armor/admin.lua
+++ b/3d_armor/admin.lua
@@ -8,6 +8,9 @@ minetest.register_tool("3d_armor:helmet_admin", {
 	inventory_image = "3d_armor_inv_helmet_admin.png",
 	groups = {armor_head=1000, armor_heal=1000, armor_use=0, not_in_creative_inventory=1},
 	wear = 0,
+	on_drop = function(itemstack, dropper, pos)
+		return
+	end,
 })
 
 minetest.register_tool("3d_armor:chestplate_admin", {
@@ -15,6 +18,9 @@ minetest.register_tool("3d_armor:chestplate_admin", {
 	inventory_image = "3d_armor_inv_chestplate_admin.png",
 	groups = {armor_torso=1000, armor_heal=1000, armor_use=0, not_in_creative_inventory=1},
 	wear = 0,
+	on_drop = function(itemstack, dropper, pos)
+		return
+	end,
 })
 
 minetest.register_tool("3d_armor:leggings_admin", {
@@ -22,6 +28,9 @@ minetest.register_tool("3d_armor:leggings_admin", {
 	inventory_image = "3d_armor_inv_leggings_admin.png",
 	groups = {armor_legs=1000, armor_heal=1000, armor_use=0, not_in_creative_inventory=1},
 	wear = 0,
+	on_drop = function(itemstack, dropper, pos)
+		return
+	end,
 })
 
 minetest.register_tool("3d_armor:boots_admin", {
@@ -29,5 +38,8 @@ minetest.register_tool("3d_armor:boots_admin", {
 	inventory_image = "3d_armor_inv_boots_admin.png",
 	groups = {armor_feet=1000, armor_heal=1000, armor_use=0, not_in_creative_inventory=1},
 	wear = 0,
+	on_drop = function(itemstack, dropper, pos)
+		return
+	end,
 })
 


### PR DESCRIPTION
Usually, because admin armor cannot be crafted, you wouldn't want it to be dropped and lost.