### PR TITLE
admin helmet lets you breathe underwater

### DIFF
--- a/3d_armor/admin.lua
+++ b/3d_armor/admin.lua
@@ -6,7 +6,7 @@ minetest.register_alias("adminlegginss","3d_armor:leggings_admin")
 minetest.register_tool("3d_armor:helmet_admin", {
 	description = "Admin Helmet",
 	inventory_image = "3d_armor_inv_helmet_admin.png",
-	groups = {armor_head=1000, armor_heal=1000, armor_use=0, not_in_creative_inventory=1},
+	groups = {armor_head=1000, armor_heal=1000, armor_use=0, armor_water=1, not_in_creative_inventory=1},
 	wear = 0,
 	on_drop = function(itemstack, dropper, pos)
 		return


### PR DESCRIPTION
added armor_water=1 group to admin helmet so players can breathe underwater.