### PR TITLE
Added insta-kill ability for tools/commands

### DIFF
--- a/3d_armor/armor.lua
+++ b/3d_armor/armor.lua
@@ -513,6 +513,12 @@ end
 minetest.register_on_player_hpchange(function(player, hp_change)
 	local name, player_inv, armor_inv = armor:get_valid_player(player, "[on_hpchange]")
 	if name and hp_change < 0 then
+
+		-- used for insta kill tools/commands like /kill (doesnt damage armor)
+		if hp_change < -100 then
+			return hp_change
+		end
+
 		local heal_max = 0
 		local state = 0
 		local items = 0
@@ -599,3 +605,15 @@ minetest.register_globalstep(function(dtime)
 	end
 	armor.timer = 0
 end)
+
+-- kill player when command issued
+minetest.register_chatcommand("kill", {
+	params = "<name>",
+	description = "Kills player instantly",
+	func = function(name, param)
+		local player = minetest.get_player_by_name(name)
+		if player then
+			player:set_hp(-1001)
+		end
+	end,
+})


### PR DESCRIPTION
Some armor was too powerful that killing yourself to respawn wouldn't work or instant kill tools for admin didn't have effect, so I've added a check so that if the player is dealt with more than -100 damage points it instantly kills them but doesn't damage armor.  Also added /kill command.