### PR TITLE
Add "ban" privilege for kill chatcommand

### DIFF
--- a/3d_armor/armor.lua
+++ b/3d_armor/armor.lua
@@ -620,10 +620,11 @@ end)
 minetest.register_chatcommand("kill", {
 	params = "<name>",
 	description = "Kills player instantly",
+	privs = {ban=true},
 	func = function(name, param)
 		local player = minetest.get_player_by_name(name)
 		if player then
-			player:set_hp(-1001)
+			player:set_hp(0)
 		end
 	end,
 })

--- a/3d_armor/armor.lua
+++ b/3d_armor/armor.lua
@@ -622,7 +622,7 @@ minetest.register_chatcommand("kill", {
 	description = "Kills player instantly",
 	privs = {ban=true},
 	func = function(name, param)
-		local player = minetest.get_player_by_name(name)
+		local player = minetest.get_player_by_name(param)
 		if player then
 			player:set_hp(0)
 		end


### PR DESCRIPTION
Only the admin should be able to execute the "kill" chatcommand
