### PR TITLE
Try harder to add armor to bones

### DIFF
--- a/3d_armor/armor.lua
+++ b/3d_armor/armor.lua
@@ -498,16 +498,22 @@ if ARMOR_DROP == true or ARMOR_DESTROY == true then
 			minetest.after(ARMOR_BONES_DELAY, function()
 				local node = minetest.get_node(vector.round(pos))
 				if node then
-					if node.name == "bones:bones" then
-						local meta = minetest.get_meta(vector.round(pos))
-						local owner = meta:get_string("owner")
-						local inv = meta:get_inventory()
-						for _,stack in ipairs(drop) do
-							if name == owner and inv:room_for_item("main", stack) then
-								inv:add_item("main", stack)
-							else
-								armor.drop_armor(pos, stack)
-							end
+					if node.name ~= "bones:bones" then
+						pos.y = pos.y+1
+						node = minetest.get_node(vector.round(pos))
+						if node.name ~= "bones:bones" then
+							minetest.log("warning", "Failed to add armor to bones node.")
+							return
+						end
+					end
+					local meta = minetest.get_meta(vector.round(pos))
+					local owner = meta:get_string("owner")
+					local inv = meta:get_inventory()
+					for _,stack in ipairs(drop) do
+						if name == owner and inv:room_for_item("main", stack) then
+							inv:add_item("main", stack)
+						else
+							armor.drop_armor(pos, stack)
 						end
 					end
 				else


### PR DESCRIPTION
Previously, if bones were on a slab, or some non-buildable_to but walkable
node, then the armor would fail to find the bones node (which is Y+1,
typically) and the armor would disappear.  This is an attempt to address that.

Attempt to address https://github.com/stujones11/minetest-3d_armor/issues/64