### PR TITLE
 Allow mod-defined wield item transformation via group 

### DIFF
--- a/wieldview/README.txt
+++ b/wieldview/README.txt
@@ -13,3 +13,11 @@ wieldview_update_time = 2
 # Show nodes as tiles, disabled by default
 wieldview_node_tiles = false
 
+
+Info for modders
+################
+
+Wield image transformation: To apply a simple transformation to the item in
+hand, add the group “wieldview_transform” to the item definition. The group
+rating equals one of the numbers used for the [transform texture modifier
+of the Lua API.

--- a/wieldview/README.txt
+++ b/wieldview/README.txt
@@ -1,7 +1,7 @@
 [mod] visible wielded items [wieldview]
 =======================================
 
-depends: default, 3d_armor
+Depends on: 3d_armor
 
 Makes hand wielded items visible to other players.
 

--- a/wieldview/depends.txt
+++ b/wieldview/depends.txt
@@ -1,2 +1,1 @@
-default
 3d_armor

--- a/wieldview/init.lua
+++ b/wieldview/init.lua
@@ -29,8 +29,15 @@ wieldview.get_item_texture = function(self, item)
 				texture = minetest.inventorycube(minetest.registered_items[item].tiles[1])
 			end
 		end
-		if wieldview.transform[item] then
-			texture = texture.."^[transform"..wieldview.transform[item]
+		-- Get item image transformation, first from group, then from transform.lua
+		local transform = minetest.get_item_group(item, "wieldview_transform")
+		if transform == 0 then
+			transform = wieldview.transform[item]
+		end
+		if transform then
+			-- This actually works with groups ratings because transform1, transform2, etc.
+			-- have meaning and transform0 is used for identidy, so it can be ignored
+			texture = texture.."^[transform"..tostring(transform)
 		end
 	end
 	return texture


### PR DESCRIPTION
This PR allows mods to define their own transformation via the new group `wieldview_transform`.
The rating equals the number used for the texture modifier `[transform`. E.g. you can use `wieldview_transform=3` for a rotation by 270 degrees.
The group takes precedence over `transform.lua`, which is still supported.

Rationale: It is better to make the mods define the correct transformation instead of trying to support all items under the sun in a single mod.

This PR also removes the `default` dependency because this mod works without `default`.