### PR TITLE
Replace deprecated methods

### DIFF
--- a/3d_armor/init.lua
+++ b/3d_armor/init.lua
@@ -41,11 +41,11 @@ end
 -- Load Configuration
 
 for name, config in pairs(armor.config) do
-	local setting = minetest.setting_get("armor_"..name)
+	local setting = minetest.settings:get("armor_"..name)
 	if type(config) == "number" then
 		setting = tonumber(setting)
 	elseif type(config) == "boolean" then
-		setting = minetest.setting_getbool("armor_"..name)
+		setting = minetest.settings:get_bool("armor_"..name)
 	end
 	if setting ~= nil then
 		armor.config[name] = setting

--- a/wieldview/init.lua
+++ b/wieldview/init.lua
@@ -1,13 +1,13 @@
 local time = 0
-local update_time = tonumber(minetest.setting_get("wieldview_update_time"))
+local update_time = tonumber(minetest.settings:get("wieldview_update_time"))
 if not update_time then
 	update_time = 2
-	minetest.setting_set("wieldview_update_time", tostring(update_time))
+	minetest.settings:set("wieldview_update_time", tostring(update_time))
 end
-local node_tiles = minetest.setting_getbool("wieldview_node_tiles")
+local node_tiles = minetest.settings:get_bool("wieldview_node_tiles")
 if not node_tiles then
 	node_tiles = false
-	minetest.setting_set("wieldview_node_tiles", "false")
+	minetest.settings:set("wieldview_node_tiles", "false")
 end
 
 wieldview = {


### PR DESCRIPTION
- 'setting_get' with 'settings:get'
- 'setting_getbool' with 'settings:get_bool'
- 'setting_set' with 'settings:set'

May not want to merge this until after 0.4.16 release, as the new ['settings' object calls][l_settings] are not available in 0.4.15.

[l_settings]: https://github.com/minetest/minetest/blob/43d1f375d18a2fbc547a9b4f23d1354d645856ca/src/script/lua_api/l_settings.cpp#L267