### PR TITLE
return the png suffix in get_player_skin

### DIFF
--- a/3d_armor/api.lua
+++ b/3d_armor/api.lua
@@ -376,15 +376,12 @@ armor.damage = function(self, player, index, stack, use)
 end
 
 armor.get_player_skin = function(self, name)
-	if self.skin_mod == "skins" or self.skin_mod == "simple_skins" and skins.skins[name] then
+	if (self.skin_mod == "skins" or self.skin_mod == "simple_skins") and skins.skins[name] then
 		return skins.skins[name]..".png"
 	elseif self.skin_mod == "u_skins" and u_skins.u_skins[name] then
 		return u_skins.u_skins[name]..".png"
-	elseif self.skin_mod == "wardrobe" then
-		local skins = wardrobe.playerSkins or {}
-		if skins[name] then
-			return skins[name]
-		end
+	elseif self.skin_mod == "wardrobe" and wardrobe.playerSkins and wardrobe.playerSkins[name] then
+		return wardrobe.playerSkins[name]
 	end
 	return armor.default_skin..".png"
 end

--- a/3d_armor/api.lua
+++ b/3d_armor/api.lua
@@ -376,18 +376,17 @@ armor.damage = function(self, player, index, stack, use)
 end
 
 armor.get_player_skin = function(self, name)
-	local skin = nil
-	if self.skin_mod == "skins" or self.skin_mod == "simple_skins" then
-		skin = skins.skins[name]
-	elseif self.skin_mod == "u_skins" then
-		skin = u_skins.u_skins[name]
+	if self.skin_mod == "skins" or self.skin_mod == "simple_skins" and skins.skins[name] then
+		return skins.skins[name]..".png"
+	elseif self.skin_mod == "u_skins" and u_skins.u_skins[name] then
+		return u_skins.u_skins[name]..".png"
 	elseif self.skin_mod == "wardrobe" then
 		local skins = wardrobe.playerSkins or {}
 		if skins[name] then
-			skin = string.gsub(skins[name], "%.png$","")
+			return skins[name]
 		end
 	end
-	return skin or armor.default_skin
+	return armor.default_skin..".png"
 end
 
 armor.add_preview = function(self, preview)
@@ -395,7 +394,7 @@ armor.add_preview = function(self, preview)
 end
 
 armor.get_preview = function(self, name)
-	local preview = armor:get_player_skin(name).."_preview.png"
+	local preview = string.gsub(armor:get_player_skin(name), ".png", "_preview.png")
 	if skin_previews[preview] then
 		return preview
 	end

--- a/3d_armor/init.lua
+++ b/3d_armor/init.lua
@@ -177,7 +177,7 @@ local function init_player_armor(player)
 	end
 	local skin = armor:get_player_skin(name)
 	armor.textures[name] = {
-		skin = skin..".png",
+		skin = skin,
 		armor = "3d_armor_trans.png",
 		wielditem = "3d_armor_trans.png",
 		preview = armor.default_skin.."_preview.png",
@@ -224,7 +224,7 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 		if string.find(field, "skins_set") then
 			minetest.after(0, function(player)
 				local skin = armor:get_player_skin(name)
-				armor.textures[name].skin = skin..".png"
+				armor.textures[name].skin = skin
 				armor:set_player_armor(player)
 			end, player)
 		end


### PR DESCRIPTION
The armor.get_player_skin() can be redefined in other mods to provide the more complex textures logic. To be proper it should return the full texture string. At usage the "*.png" should not be enforced on apply