### PR TITLE
Replace deprecated function 'intllib.Getter'

### DIFF
--- a/3d_armor/armor.lua
+++ b/3d_armor/armor.lua
@@ -1,6 +1,12 @@
 local S = function(s) return s end
 if minetest.global_exists("intllib") then
-	S = intllib.Getter()
+	if intllib.make_gettext_pair then
+		-- New method using gettext.
+		S = intllib.make_gettext_pair()
+	else
+		-- Old method using text files.
+		S = intllib.Getter()
+	end
 end
 
 armor:register_armor("3d_armor:helmet_admin", {

--- a/3d_armor/init.lua
+++ b/3d_armor/init.lua
@@ -1,6 +1,12 @@
 local S = function(s) return s end
 if minetest.global_exists("intllib") then
-	S = intllib.Getter()
+	if intllib.make_gettext_pair then
+		-- New method using gettext.
+		S = intllib.make_gettext_pair()
+	else
+		-- Old method using text files.
+		S = intllib.Getter()
+	end
 end
 local modname = minetest.get_current_modname()
 local modpath = minetest.get_modpath(modname)

--- a/3d_armor_stand/init.lua
+++ b/3d_armor_stand/init.lua
@@ -1,6 +1,12 @@
 local S = function(s) return s end
 if minetest.global_exists("intllib") then
-	S = intllib.Getter()
+	if intllib.make_gettext_pair then
+		-- New method using gettext.
+		S = intllib.make_gettext_pair()
+	else
+		-- Old method using text files.
+		S = intllib.Getter()
+	end
 end
 local armor_stand_formspec = "size[8,7]" ..
 	default.gui_bg ..

--- a/3d_armor_ui/init.lua
+++ b/3d_armor_ui/init.lua
@@ -4,7 +4,13 @@ if not minetest.global_exists("unified_inventory") then
 end
 local S = function(s) return s end
 if minetest.global_exists("intllib") then
-	S = intllib.Getter()
+	if intllib.make_gettext_pair then
+		-- New method using gettext.
+		S = intllib.make_gettext_pair()
+	else
+		-- Old method using text files.
+		S = intllib.Getter()
+	end
 end
 
 if unified_inventory.sfinv_compat_layer then

--- a/hazmat_suit/init.lua
+++ b/hazmat_suit/init.lua
@@ -4,7 +4,13 @@ if not minetest.get_modpath("technic") then
 end
 local S = function(s) return s end
 if minetest.global_exists("intllib") then
-	S = intllib.Getter()
+	if intllib.make_gettext_pair then
+		-- New method using gettext.
+		S = intllib.make_gettext_pair()
+	else
+		-- Old method using text files.
+		S = intllib.Getter()
+	end
 end
 
 minetest.register_craftitem("hazmat_suit:helmet_hazmat", {

--- a/shields/init.lua
+++ b/shields/init.lua
@@ -1,6 +1,12 @@
 local S = function(s) return s end
 if minetest.global_exists("intllib") then
-	S = intllib.Getter()
+	if intllib.make_gettext_pair then
+		-- New method using gettext.
+		S = intllib.make_gettext_pair()
+	else
+		-- Old method using text files.
+		S = intllib.Getter()
+	end
 end
 local use_moreores = minetest.get_modpath("moreores")
 local function play_sound_effect(player, name)

--- a/technic_armor/init.lua
+++ b/technic_armor/init.lua
@@ -4,7 +4,13 @@ if not minetest.get_modpath("technic_worldgen") then
 end
 local S = function(s) return s end
 if minetest.global_exists("intllib") then
-	S = intllib.Getter()
+	if intllib.make_gettext_pair then
+		-- New method using gettext.
+		S = intllib.make_gettext_pair()
+	else
+		-- Old method using text files.
+		S = intllib.Getter()
+	end
 end
 
 local stats = {


### PR DESCRIPTION
- Check first for *intllib.make_gettext_pair*, otherwise continue using function *intllib.Getter*.