### PR TITLE
complete intllib support (i18n)

### DIFF
--- a/3d_armor/api.lua
+++ b/3d_armor/api.lua
@@ -1,3 +1,6 @@
+-- support for i18n
+local S = armor_i18n.gettext
+
 local skin_previews = {}
 local use_player_monoids = minetest.global_exists("player_monoids")
 local use_armor_monoid = minetest.global_exists("armor_monoid")
@@ -427,16 +430,16 @@ armor.set_inventory_stack = function(self, player, i, stack)
 	local msg = "[set_inventory_stack]"
 	local name = player:get_player_name()
 	if not name then
-		minetest.log("warning", "3d_armor: Player name is nil "..msg)
+		minetest.log("warning", S("3d_armor: Player name is nil @1", msg))
 		return
 	end
 	local player_inv = player:get_inventory()
 	local armor_inv = minetest.get_inventory({type="detached", name=name.."_armor"})
 	if not player_inv then
-		minetest.log("warning", "3d_armor: Player inventory is nil "..msg)
+		minetest.log("warning", S("3d_armor: Player inventory is nil @1", msg))
 		return
 	elseif not armor_inv then
-		minetest.log("warning", "3d_armor: Detached armor inventory is nil "..msg)
+		minetest.log("warning", S("3d_armor: Detached armor inventory is nil @1", msg))
 		return
 	end
 	player_inv:set_stack("armor", i, stack)
@@ -446,17 +449,17 @@ end
 armor.get_valid_player = function(self, player, msg)
 	msg = msg or ""
 	if not player then
-		minetest.log("warning", "3d_armor: Player reference is nil "..msg)
+		minetest.log("warning", S("3d_armor: Player reference is nil @1", msg))
 		return
 	end
 	local name = player:get_player_name()
 	if not name then
-		minetest.log("warning", "3d_armor: Player name is nil "..msg)
+		minetest.log("warning", S("3d_armor: Player name is nil @1", msg))
 		return
 	end
 	local inv = player:get_inventory()
 	if not inv then
-		minetest.log("warning", "3d_armor: Player inventory is nil "..msg)
+		minetest.log("warning", S("3d_armor: Player inventory is nil @1", msg))
 		return
 	end
 	return name, inv

--- a/3d_armor/armor.lua
+++ b/3d_armor/armor.lua
@@ -1,13 +1,5 @@
-local S = function(s) return s end
-if minetest.global_exists("intllib") then
-	if intllib.make_gettext_pair then
-		-- New method using gettext.
-		S = intllib.make_gettext_pair()
-	else
-		-- Old method using text files.
-		S = intllib.Getter()
-	end
-end
+-- support for i18n
+local S = armor_i18n.gettext
 
 armor:register_armor("3d_armor:helmet_admin", {
 	description = S("Admin Helmet"),

--- a/3d_armor/init.lua
+++ b/3d_armor/init.lua
@@ -1,13 +1,13 @@
-local S = function(s) return s end
-if minetest.global_exists("intllib") then
-	if intllib.make_gettext_pair then
-		-- New method using gettext.
-		S = intllib.make_gettext_pair()
-	else
-		-- Old method using text files.
-		S = intllib.Getter()
-	end
-end
+-- support for i18n
+armor_i18n = { }
+local MP = minetest.get_modpath(minetest.get_current_modname())
+armor_i18n.gettext, armor_i18n.ngettext = dofile(MP.."/intllib.lua")
+-- escaping formspec
+armor_i18n.fgettext = function(...) return minetest.formspec_escape(armor_i18n.gettext(...)) end
+-- local functions
+local S = armor_i18n.gettext
+local F = armor_i18n.fgettext
+
 local modname = minetest.get_current_modname()
 local modpath = minetest.get_modpath(modname)
 local worldpath = minetest.get_worldpath()
@@ -68,7 +68,7 @@ end
 
 if minetest.get_modpath("technic") then
 	armor.formspec = armor.formspec..
-		"label[5,2.5;"..S("Radiation")..":  armor_group_radiation]"
+		"label[5,2.5;"..F("Radiation")..":  armor_group_radiation]"
 	armor:register_armor_group("radiation")
 end
 local skin_mods = {"skins", "u_skins", "simple_skins", "wardrobe"}
@@ -96,17 +96,16 @@ dofile(modpath.."/armor.lua")
 -- Armor Initialization
 
 armor.formspec = armor.formspec..
-	"label[5,1;"..S("Level")..": armor_level]"..
-	"label[5,1.5;"..S("Heal")..":  armor_attr_heal]"
+	"label[5,1;"..F("Level")..": armor_level]"..
+	"label[5,1.5;"..F("Heal")..":  armor_attr_heal]"
 if armor.config.fire_protect then
-	armor.formspec = armor.formspec.."label[5,2;"..S("Fire")..":  armor_fire]"
+	armor.formspec = armor.formspec.."label[5,2;"..F("Fire")..":  armor_fire]"
 end
 armor:register_on_destroy(function(player, index, stack)
 	local name = player:get_player_name()
 	local def = stack:get_definition()
 	if name and def and def.description then
-		minetest.chat_send_player(name, S("Your").." "..def.description.." "..
-			S("got destroyed").."!")
+		minetest.chat_send_player(name, S("Your @1 got destroyed!", def.description))
 	end
 end)
 
@@ -341,7 +340,7 @@ minetest.register_globalstep(function(dtime)
 			local remove = init_player_armor(player) == true
 			pending_players[player] = count + 1
 			if remove == false and count > armor.config.init_times then
-				minetest.log("warning", "3d_armor: Failed to initialize player")
+				minetest.log("warning", S("3d_armor: Failed to initialize player"))
 				remove = true
 			end
 			if remove == true then
@@ -362,7 +361,7 @@ if armor.config.fire_protect == true then
 		end
 	end
 else
-	print ("[3d_armor] Fire Nodes disabled")
+	print (S("[3d_armor] Fire Nodes disabled"))
 end
 
 if armor.config.water_protect == true or armor.config.fire_protect == true then

--- a/3d_armor/intllib.lua
+++ b/3d_armor/intllib.lua
@@ -1,0 +1,45 @@
+
+-- Fallback functions for when `intllib` is not installed.
+-- Code released under Unlicense <http://unlicense.org>.
+
+-- Get the latest version of this file at:
+--   https://raw.githubusercontent.com/minetest-mods/intllib/master/lib/intllib.lua
+
+local function format(str, ...)
+	local args = { ... }
+	local function repl(escape, open, num, close)
+		if escape == "" then
+			local replacement = tostring(args[tonumber(num)])
+			if open == "" then
+				replacement = replacement..close
+			end
+			return replacement
+		else
+			return "@"..open..num..close
+		end
+	end
+	return (str:gsub("(@?)@(%(?)(%d+)(%)?)", repl))
+end
+
+local gettext, ngettext
+if minetest.get_modpath("intllib") then
+	if intllib.make_gettext_pair then
+		-- New method using gettext.
+		gettext, ngettext = intllib.make_gettext_pair()
+	else
+		-- Old method using text files.
+		gettext = intllib.Getter()
+	end
+end
+
+-- Fill in missing functions.
+
+gettext = gettext or function(msgid, ...)
+	return format(msgid, ...)
+end
+
+ngettext = ngettext or function(msgid, msgid_plural, n, ...)
+	return format(n==1 and msgid or msgid_plural, ...)
+end
+
+return gettext, ngettext

--- a/3d_armor/locale/fr.po
+++ b/3d_armor/locale/fr.po
@@ -1,0 +1,384 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-08-06 18:20+0200\n"
+"PO-Revision-Date: 2017-08-06 18:20+0200\n"
+"Last-Translator: fat115 <fat115@framasoft.org>\n"
+"Language-Team: \n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 1.8.12\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: ../3d_armor/api.lua
+msgid "3d_armor: Player name is nil @1"
+msgstr "3d_armor : Nom du joueur non trouvé @1"
+
+#: ../3d_armor/api.lua
+msgid "3d_armor: Player inventory is nil @1"
+msgstr "3d_armor : Inventaire du joueur non trouvé @1"
+
+#: ../3d_armor/api.lua
+msgid "3d_armor: Detached armor inventory is nil @1"
+msgstr "3d_armor : Inventaire détaché pour l'armure non trouvé @1"
+
+#: ../3d_armor/api.lua
+msgid "3d_armor: Player reference is nil @1"
+msgstr "3d_armor : Référence au joueur non trouvée @1"
+
+#: ../3d_armor/armor.lua
+msgid "Admin Helmet"
+msgstr "Casque d'admin"
+
+#: ../3d_armor/armor.lua
+msgid "Admin Chestplate"
+msgstr "Cuirasse d'admin"
+
+#: ../3d_armor/armor.lua
+msgid "Admin Leggings"
+msgstr "Jambières d'admin"
+
+#: ../3d_armor/armor.lua
+msgid "Admin Boots"
+msgstr "Bottes d'admin"
+
+#: ../3d_armor/armor.lua
+msgid "Wood Helmet"
+msgstr "Casque en bois"
+
+#: ../3d_armor/armor.lua
+msgid "Wood Chestplate"
+msgstr "Cuirasse en bois"
+
+#: ../3d_armor/armor.lua
+msgid "Wood Leggings"
+msgstr "Jambières en bois"
+
+#: ../3d_armor/armor.lua
+msgid "Wood Boots"
+msgstr "Bottes en bois"
+
+#: ../3d_armor/armor.lua
+msgid "Cactus Helmet"
+msgstr "Casque en cactus"
+
+#: ../3d_armor/armor.lua
+msgid "Cactus Chestplate"
+msgstr "Cuirasse en cactus"
+
+#: ../3d_armor/armor.lua
+msgid "Cactus Leggings"
+msgstr "Jambières en cactus"
+
+#: ../3d_armor/armor.lua
+msgid "Cactus Boots"
+msgstr "Bottes en cactus"
+
+#: ../3d_armor/armor.lua
+msgid "Steel Helmet"
+msgstr "Casque en acier"
+
+#: ../3d_armor/armor.lua
+msgid "Steel Chestplate"
+msgstr " = Cuirasse en acier"
+
+#: ../3d_armor/armor.lua
+msgid "Steel Leggings"
+msgstr "Jambières en acier"
+
+#: ../3d_armor/armor.lua
+msgid "Steel Boots"
+msgstr "Bottes en acier"
+
+#: ../3d_armor/armor.lua
+msgid "Bronze Helmet"
+msgstr "Casque en bronze"
+
+#: ../3d_armor/armor.lua
+msgid "Bronze Chestplate"
+msgstr "Cuirasse en bronze"
+
+#: ../3d_armor/armor.lua
+msgid "Bronze Leggings"
+msgstr "Jambières en bronze"
+
+#: ../3d_armor/armor.lua
+msgid "Bronze Boots"
+msgstr "Bottes en bronze"
+
+#: ../3d_armor/armor.lua
+msgid "Diamond Helmet"
+msgstr "Casque en diamant"
+
+#: ../3d_armor/armor.lua
+msgid "Diamond Chestplate"
+msgstr "Cuirasse en diamant"
+
+#: ../3d_armor/armor.lua
+msgid "Diamond Leggings"
+msgstr "Jambières en diamant"
+
+#: ../3d_armor/armor.lua
+msgid "Diamond Boots"
+msgstr "Bottes en diamant"
+
+#: ../3d_armor/armor.lua
+msgid "Gold Helmet"
+msgstr "Casque en or"
+
+#: ../3d_armor/armor.lua
+msgid "Gold Chestplate"
+msgstr "Cuirasse en or"
+
+#: ../3d_armor/armor.lua
+msgid "Gold Leggings"
+msgstr "Jambières en or"
+
+#: ../3d_armor/armor.lua
+msgid "Gold Boots"
+msgstr "Bottes en or"
+
+#: ../3d_armor/armor.lua
+msgid "Mithril Helmet"
+msgstr "Casque en mithril"
+
+#: ../3d_armor/armor.lua
+msgid "Mithril Chestplate"
+msgstr "Cuirasse en mithril"
+
+#: ../3d_armor/armor.lua
+msgid "Mithril Leggings"
+msgstr "Jambières en mithril"
+
+#: ../3d_armor/armor.lua
+msgid "Mithril Boots"
+msgstr "Bottes en mithril"
+
+#: ../3d_armor/armor.lua
+msgid "Crystal Helmet"
+msgstr "Casque en cristal"
+
+#: ../3d_armor/armor.lua
+msgid "Crystal Chestplate"
+msgstr "Cuirasse en cristal"
+
+#: ../3d_armor/armor.lua
+msgid "Crystal Leggings"
+msgstr "Jambières en cristal"
+
+#: ../3d_armor/armor.lua
+msgid "Crystal Boots"
+msgstr "Bottes en cristal"
+
+#: ../3d_armor/init.lua ../3d_armor_ui/init.lua
+msgid "Radiation"
+msgstr "Radiation"
+
+#: ../3d_armor/init.lua ../3d_armor_ui/init.lua
+msgid "Level"
+msgstr "Niveau"
+
+#: ../3d_armor/init.lua ../3d_armor_ui/init.lua
+msgid "Heal"
+msgstr "Soins"
+
+#: ../3d_armor/init.lua ../3d_armor_ui/init.lua
+msgid "Fire"
+msgstr "Fire"
+
+#: ../3d_armor/init.lua
+msgid "Your @1 got destroyed!"
+msgstr "Une partie de votre armure a été détruite : @1 !"
+
+#: ../3d_armor/init.lua
+msgid "3d_armor: Failed to initialize player"
+msgstr "3d_armor : Impossible d'initialiser le joueur"
+
+#: ../3d_armor/init.lua
+msgid "[3d_armor] Fire Nodes disabled"
+msgstr "[3d_armor] Noeuds de type feu désactivés"
+
+#: ../3d_armor_ip/init.lua
+msgid "3d_armor_ip: Mod loaded but unused."
+msgstr "3d_armor_ip : Mod chargé mais inutilisé."
+
+#: ../3d_armor_ip/init.lua
+msgid "Back"
+msgstr "Retour"
+
+#: ../3d_armor_ip/init.lua ../3d_armor_sfinv/init.lua ../3d_armor_ui/init.lua
+msgid "Armor"
+msgstr "Armure"
+
+#: ../3d_armor_sfinv/init.lua
+msgid "3d_armor_sfinv: Mod loaded but unused."
+msgstr "3d_armor_sfinv : Mod chargé mais inutilisé."
+
+#: ../3d_armor_stand/init.lua
+msgid "Armor stand top"
+msgstr "Haut de support d'armure"
+
+#: ../3d_armor_stand/init.lua
+msgid "Armor stand"
+msgstr "Support d'armure"
+
+#: ../3d_armor_stand/init.lua
+msgid "Armor Stand"
+msgstr "Support d'armure"
+
+#: ../3d_armor_stand/init.lua
+msgid "Locked Armor stand"
+msgstr "Support d'armure verrouillé"
+
+#: ../3d_armor_stand/init.lua
+msgid "Armor Stand (owned by @1)"
+msgstr "Support d'armure (propriété de @1)"
+
+#: ../3d_armor_ui/init.lua
+msgid "3d_armor_ui: Mod loaded but unused."
+msgstr "3d_armor_ui : Mod chargé mais inutilisé."
+
+#: ../3d_armor_ui/init.lua
+msgid "3d Armor"
+msgstr "Armure 3d"
+
+#: ../3d_armor_ui/init.lua
+msgid "Armor not initialized!"
+msgstr "Armure non initialisée !"
+
+#: ../hazmat_suit/init.lua
+msgid "hazmat_suit: Mod loaded but unused."
+msgstr "hazmat_suit : Mod chargé mais non utilisé."
+
+#: ../hazmat_suit/init.lua
+msgid "Hazmat Helmet"
+msgstr "Casque 'Hazmat'"
+
+#: ../hazmat_suit/init.lua
+msgid "Hazmat Chestplate"
+msgstr "Cuirasse 'Hazmat'"
+
+#: ../hazmat_suit/init.lua
+msgid "Hazmat Sleeve"
+msgstr "Manches 'Hazmat'"
+
+#: ../hazmat_suit/init.lua
+msgid "Hazmat Leggins"
+msgstr "Jambières 'Hazmat'"
+
+#: ../hazmat_suit/init.lua
+msgid "Hazmat Boots"
+msgstr "Bottes 'Hazmat'"
+
+#: ../hazmat_suit/init.lua
+msgid "Hazmat Suit"
+msgstr "Combinaison 'Hazmat'"
+
+#: ../shields/init.lua
+msgid "Admin Shield"
+msgstr "Bouclier d'admin"
+
+#: ../shields/init.lua
+msgid "Wooden Shield"
+msgstr "Bouclier en bois"
+
+#: ../shields/init.lua
+msgid "Enhanced Wood Shield"
+msgstr "Bouclier en bois amélioré"
+
+#: ../shields/init.lua
+msgid "Cactus Shield"
+msgstr "Bouclier en cactus"
+
+#: ../shields/init.lua
+msgid "Enhanced Cactus Shield"
+msgstr "Bouclier en cactus amélioré"
+
+#: ../shields/init.lua
+msgid "Steel Shield"
+msgstr "Bouclier en acier"
+
+#: ../shields/init.lua
+msgid "Bronze Shield"
+msgstr "Bouclier en bronze"
+
+#: ../shields/init.lua
+msgid "Diamond Shield"
+msgstr "Bouclier en diamant"
+
+#: ../shields/init.lua
+msgid "Gold Shield"
+msgstr "Bouclier en or"
+
+#: ../shields/init.lua
+msgid "Mithril Shield"
+msgstr "Bouclier en mithril"
+
+#: ../shields/init.lua
+msgid "Crystal Shield"
+msgstr "Bouclier en cristal"
+
+#: ../technic_armor/init.lua
+msgid "technic_armor: Mod loaded but unused."
+msgstr "technic_armor : Mod chargé mais non utilisé."
+
+#: ../technic_armor/init.lua
+msgid "Lead"
+msgstr "plomb"
+
+#: ../technic_armor/init.lua
+msgid "Brass"
+msgstr "laiton"
+
+#: ../technic_armor/init.lua
+msgid "Cast Iron"
+msgstr "fonte"
+
+#: ../technic_armor/init.lua
+msgid "Carbon Steel"
+msgstr "acier au carbone"
+
+#: ../technic_armor/init.lua
+msgid "Stainless Steel"
+msgstr "acier inoxydable"
+
+#: ../technic_armor/init.lua
+msgid "Tin"
+msgstr "étain"
+
+#: ../technic_armor/init.lua
+msgid "Silver"
+msgstr "argent"
+
+#: ../technic_armor/init.lua
+msgid "Helmet"
+msgstr "Casque"
+
+#: ../technic_armor/init.lua
+msgid "Chestplate"
+msgstr "Cuirasse"
+
+#: ../technic_armor/init.lua
+msgid "Leggings"
+msgstr "Jambières"
+
+#: ../technic_armor/init.lua
+msgid "Boots"
+msgstr "Bottes"
+
+#: ../technic_armor/init.lua
+msgid "Shield"
+msgstr "Bouclier"
+
+#. Translators: @1 stands for material and @2 for part of the armor, so that you could use a conjunction if in your language part name comes first then material (e.g. in french 'Silver Boots' is translated in 'Bottes en argent' by using '@2 en @1' as translated string)
+#: ../technic_armor/init.lua
+msgid "@1 @2"
+msgstr "@2 en @1"

--- a/3d_armor/locale/template.pot
+++ b/3d_armor/locale/template.pot
@@ -1,0 +1,383 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-08-06 18:20+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../3d_armor/api.lua
+msgid "3d_armor: Player name is nil @1"
+msgstr ""
+
+#: ../3d_armor/api.lua
+msgid "3d_armor: Player inventory is nil @1"
+msgstr ""
+
+#: ../3d_armor/api.lua
+msgid "3d_armor: Detached armor inventory is nil @1"
+msgstr ""
+
+#: ../3d_armor/api.lua
+msgid "3d_armor: Player reference is nil @1"
+msgstr ""
+
+#: ../3d_armor/armor.lua
+msgid "Admin Helmet"
+msgstr ""
+
+#: ../3d_armor/armor.lua
+msgid "Admin Chestplate"
+msgstr ""
+
+#: ../3d_armor/armor.lua
+msgid "Admin Leggings"
+msgstr ""
+
+#: ../3d_armor/armor.lua
+msgid "Admin Boots"
+msgstr ""
+
+#: ../3d_armor/armor.lua
+msgid "Wood Helmet"
+msgstr ""
+
+#: ../3d_armor/armor.lua
+msgid "Wood Chestplate"
+msgstr ""
+
+#: ../3d_armor/armor.lua
+msgid "Wood Leggings"
+msgstr ""
+
+#: ../3d_armor/armor.lua
+msgid "Wood Boots"
+msgstr ""
+
+#: ../3d_armor/armor.lua
+msgid "Cactus Helmet"
+msgstr ""
+
+#: ../3d_armor/armor.lua
+msgid "Cactus Chestplate"
+msgstr ""
+
+#: ../3d_armor/armor.lua
+msgid "Cactus Leggings"
+msgstr ""
+
+#: ../3d_armor/armor.lua
+msgid "Cactus Boots"
+msgstr ""
+
+#: ../3d_armor/armor.lua
+msgid "Steel Helmet"
+msgstr ""
+
+#: ../3d_armor/armor.lua
+msgid "Steel Chestplate"
+msgstr ""
+
+#: ../3d_armor/armor.lua
+msgid "Steel Leggings"
+msgstr ""
+
+#: ../3d_armor/armor.lua
+msgid "Steel Boots"
+msgstr ""
+
+#: ../3d_armor/armor.lua
+msgid "Bronze Helmet"
+msgstr ""
+
+#: ../3d_armor/armor.lua
+msgid "Bronze Chestplate"
+msgstr ""
+
+#: ../3d_armor/armor.lua
+msgid "Bronze Leggings"
+msgstr ""
+
+#: ../3d_armor/armor.lua
+msgid "Bronze Boots"
+msgstr ""
+
+#: ../3d_armor/armor.lua
+msgid "Diamond Helmet"
+msgstr ""
+
+#: ../3d_armor/armor.lua
+msgid "Diamond Chestplate"
+msgstr ""
+
+#: ../3d_armor/armor.lua
+msgid "Diamond Leggings"
+msgstr ""
+
+#: ../3d_armor/armor.lua
+msgid "Diamond Boots"
+msgstr ""
+
+#: ../3d_armor/armor.lua
+msgid "Gold Helmet"
+msgstr ""
+
+#: ../3d_armor/armor.lua
+msgid "Gold Chestplate"
+msgstr ""
+
+#: ../3d_armor/armor.lua
+msgid "Gold Leggings"
+msgstr ""
+
+#: ../3d_armor/armor.lua
+msgid "Gold Boots"
+msgstr ""
+
+#: ../3d_armor/armor.lua
+msgid "Mithril Helmet"
+msgstr ""
+
+#: ../3d_armor/armor.lua
+msgid "Mithril Chestplate"
+msgstr ""
+
+#: ../3d_armor/armor.lua
+msgid "Mithril Leggings"
+msgstr ""
+
+#: ../3d_armor/armor.lua
+msgid "Mithril Boots"
+msgstr ""
+
+#: ../3d_armor/armor.lua
+msgid "Crystal Helmet"
+msgstr ""
+
+#: ../3d_armor/armor.lua
+msgid "Crystal Chestplate"
+msgstr ""
+
+#: ../3d_armor/armor.lua
+msgid "Crystal Leggings"
+msgstr ""
+
+#: ../3d_armor/armor.lua
+msgid "Crystal Boots"
+msgstr ""
+
+#: ../3d_armor/init.lua ../3d_armor_ui/init.lua
+msgid "Radiation"
+msgstr ""
+
+#: ../3d_armor/init.lua ../3d_armor_ui/init.lua
+msgid "Level"
+msgstr ""
+
+#: ../3d_armor/init.lua ../3d_armor_ui/init.lua
+msgid "Heal"
+msgstr ""
+
+#: ../3d_armor/init.lua ../3d_armor_ui/init.lua
+msgid "Fire"
+msgstr ""
+
+#: ../3d_armor/init.lua
+msgid "Your @1 got destroyed!"
+msgstr ""
+
+#: ../3d_armor/init.lua
+msgid "3d_armor: Failed to initialize player"
+msgstr ""
+
+#: ../3d_armor/init.lua
+msgid "[3d_armor] Fire Nodes disabled"
+msgstr ""
+
+#: ../3d_armor_ip/init.lua
+msgid "3d_armor_ip: Mod loaded but unused."
+msgstr ""
+
+#: ../3d_armor_ip/init.lua
+msgid "Back"
+msgstr ""
+
+#: ../3d_armor_ip/init.lua ../3d_armor_sfinv/init.lua ../3d_armor_ui/init.lua
+msgid "Armor"
+msgstr ""
+
+#: ../3d_armor_sfinv/init.lua
+msgid "3d_armor_sfinv: Mod loaded but unused."
+msgstr ""
+
+#: ../3d_armor_stand/init.lua
+msgid "Armor stand top"
+msgstr ""
+
+#: ../3d_armor_stand/init.lua
+msgid "Armor stand"
+msgstr ""
+
+#: ../3d_armor_stand/init.lua
+msgid "Armor Stand"
+msgstr ""
+
+#: ../3d_armor_stand/init.lua
+msgid "Locked Armor stand"
+msgstr ""
+
+#: ../3d_armor_stand/init.lua
+msgid "Armor Stand (owned by @1)"
+msgstr ""
+
+#: ../3d_armor_ui/init.lua
+msgid "3d_armor_ui: Mod loaded but unused."
+msgstr ""
+
+#: ../3d_armor_ui/init.lua
+msgid "3d Armor"
+msgstr ""
+
+#: ../3d_armor_ui/init.lua
+msgid "Armor not initialized!"
+msgstr ""
+
+#: ../hazmat_suit/init.lua
+msgid "hazmat_suit: Mod loaded but unused."
+msgstr ""
+
+#: ../hazmat_suit/init.lua
+msgid "Hazmat Helmet"
+msgstr ""
+
+#: ../hazmat_suit/init.lua
+msgid "Hazmat Chestplate"
+msgstr ""
+
+#: ../hazmat_suit/init.lua
+msgid "Hazmat Sleeve"
+msgstr ""
+
+#: ../hazmat_suit/init.lua
+msgid "Hazmat Leggins"
+msgstr ""
+
+#: ../hazmat_suit/init.lua
+msgid "Hazmat Boots"
+msgstr ""
+
+#: ../hazmat_suit/init.lua
+msgid "Hazmat Suit"
+msgstr ""
+
+#: ../shields/init.lua
+msgid "Admin Shield"
+msgstr ""
+
+#: ../shields/init.lua
+msgid "Wooden Shield"
+msgstr ""
+
+#: ../shields/init.lua
+msgid "Enhanced Wood Shield"
+msgstr ""
+
+#: ../shields/init.lua
+msgid "Cactus Shield"
+msgstr ""
+
+#: ../shields/init.lua
+msgid "Enhanced Cactus Shield"
+msgstr ""
+
+#: ../shields/init.lua
+msgid "Steel Shield"
+msgstr ""
+
+#: ../shields/init.lua
+msgid "Bronze Shield"
+msgstr ""
+
+#: ../shields/init.lua
+msgid "Diamond Shield"
+msgstr ""
+
+#: ../shields/init.lua
+msgid "Gold Shield"
+msgstr ""
+
+#: ../shields/init.lua
+msgid "Mithril Shield"
+msgstr ""
+
+#: ../shields/init.lua
+msgid "Crystal Shield"
+msgstr ""
+
+#: ../technic_armor/init.lua
+msgid "technic_armor: Mod loaded but unused."
+msgstr ""
+
+#: ../technic_armor/init.lua
+msgid "Lead"
+msgstr ""
+
+#: ../technic_armor/init.lua
+msgid "Brass"
+msgstr ""
+
+#: ../technic_armor/init.lua
+msgid "Cast Iron"
+msgstr ""
+
+#: ../technic_armor/init.lua
+msgid "Carbon Steel"
+msgstr ""
+
+#: ../technic_armor/init.lua
+msgid "Stainless Steel"
+msgstr ""
+
+#: ../technic_armor/init.lua
+msgid "Tin"
+msgstr ""
+
+#: ../technic_armor/init.lua
+msgid "Silver"
+msgstr ""
+
+#: ../technic_armor/init.lua
+msgid "Helmet"
+msgstr ""
+
+#: ../technic_armor/init.lua
+msgid "Chestplate"
+msgstr ""
+
+#: ../technic_armor/init.lua
+msgid "Leggings"
+msgstr ""
+
+#: ../technic_armor/init.lua
+msgid "Boots"
+msgstr ""
+
+#: ../technic_armor/init.lua
+msgid "Shield"
+msgstr ""
+
+#. Translators: @1 stands for material and @2 for part of the armor, so that you could use a conjunction if in your language part name comes first then material (e.g. in french 'Silver Boots' is translated in 'Bottes en argent' by using '@2 en @1' as translated string)
+#: ../technic_armor/init.lua
+msgid "@1 @2"
+msgstr ""

--- a/3d_armor/tools/updatepo.sh
+++ b/3d_armor/tools/updatepo.sh
@@ -1,0 +1,25 @@
+#! /bin/bash
+
+# To create a new translation:
+#   msginit --locale=ll_CC -o locale/ll_CC.po -i locale/template.pot
+
+cd "$(dirname "${BASH_SOURCE[0]}")/..";
+
+# Extract translatable strings.
+xgettext --from-code=UTF-8 \
+		--language=Lua \
+		--sort-by-file \
+		--keyword=S \
+		--keyword=NS:1,2 \
+		--keyword=N_ \
+		--keyword=F \
+		--add-comments='Translators:' \
+		--add-location=file \
+		-o locale/template.pot \
+		$(find .. -name '*.lua')
+
+# Update translations.
+find locale -name '*.po' | while read -r file; do
+	echo $file
+	msgmerge --update $file locale/template.pot;
+done

--- a/3d_armor_ip/init.lua
+++ b/3d_armor_ip/init.lua
@@ -1,9 +1,13 @@
+-- support for i18n
+local S = armor_i18n.gettext
+local F = armor_i18n.fgettext
+
 if not minetest.global_exists("inventory_plus") then
-	minetest.log("warning", "3d_armor_ip: Mod loaded but unused.")
+	minetest.log("warning", S("3d_armor_ip: Mod loaded but unused."))
 	return
 end
 
-armor.formspec = "size[8,8.5]button[6,0;2,0.5;main;Back]"..armor.formspec
+armor.formspec = "size[8,8.5]button[6,0;2,0.5;main;"..F("Back").."]"..armor.formspec
 armor:register_on_update(function(player)
 	local name = player:get_player_name()
 	local formspec = armor:get_armor_formspec(name, true)
@@ -19,7 +23,7 @@ if minetest.get_modpath("crafting") then
 end
 
 minetest.register_on_joinplayer(function(player)
-	inventory_plus.register_button(player,"armor", "Armor")
+	inventory_plus.register_button(player,"armor", S("Armor"))
 end)
 
 minetest.register_on_player_receive_fields(function(player, formname, fields)

--- a/3d_armor_sfinv/init.lua
+++ b/3d_armor_sfinv/init.lua
@@ -1,10 +1,13 @@
+-- support for i18n
+local S = armor_i18n.gettext
+
 if not minetest.global_exists("sfinv") then
-	minetest.log("warning", "3d_armor_sfinv: Mod loaded but unused.")
+	minetest.log("warning", S("3d_armor_sfinv: Mod loaded but unused."))
 	return
 end
 
 sfinv.register_page("3d_armor:armor", {
-	title = "Armor",
+	title = S("Armor"),
 	get = function(self, player, context)
 		local name = player:get_player_name()
 		local formspec = armor:get_armor_formspec(name, true)

--- a/3d_armor_stand/init.lua
+++ b/3d_armor_stand/init.lua
@@ -1,13 +1,6 @@
-local S = function(s) return s end
-if minetest.global_exists("intllib") then
-	if intllib.make_gettext_pair then
-		-- New method using gettext.
-		S = intllib.make_gettext_pair()
-	else
-		-- Old method using text files.
-		S = intllib.Getter()
-	end
-end
+-- support for i18n
+local S = armor_i18n.gettext
+
 local armor_stand_formspec = "size[8,7]" ..
 	default.gui_bg ..
 	default.gui_bg_img ..
@@ -172,7 +165,7 @@ minetest.register_node("3d_armor_stand:armor_stand", {
 	on_construct = function(pos)
 		local meta = minetest.get_meta(pos)
 		meta:set_string("formspec", armor_stand_formspec)
-		meta:set_string("infotext", "Armor Stand")
+		meta:set_string("infotext", S("Armor Stand"))
 		local inv = meta:get_inventory()
 		for _, element in pairs(elements) do
 			inv:set_size("armor_"..element, 1)
@@ -240,7 +233,7 @@ minetest.register_node("3d_armor_stand:locked_armor_stand", {
 	on_construct = function(pos)
 		local meta = minetest.get_meta(pos)
 		meta:set_string("formspec", armor_stand_formspec)
-		meta:set_string("infotext", "Armor Stand")
+		meta:set_string("infotext", S("Armor Stand"))
 		meta:set_string("owner", "")
 		local inv = meta:get_inventory()
 		for _, element in pairs(elements) do
@@ -261,8 +254,7 @@ minetest.register_node("3d_armor_stand:locked_armor_stand", {
 		minetest.add_entity(pos, "3d_armor_stand:armor_entity")
 		local meta = minetest.get_meta(pos)
 		meta:set_string("owner", placer:get_player_name() or "")
-		meta:set_string("infotext", "Armor Stand (owned by " ..
-		meta:get_string("owner") .. ")")
+		meta:set_string("infotext", S("Armor Stand (owned by @1)", meta:get_string("owner")))
 		add_hidden_node(pos, placer)
 	end,
 	allow_metadata_inventory_put = function(pos, listname, index, stack, player)
@@ -344,4 +336,3 @@ minetest.register_craft({
 		{"3d_armor_stand:armor_stand", "default:steel_ingot"},
 	}
 })
-

--- a/3d_armor_ui/init.lua
+++ b/3d_armor_ui/init.lua
@@ -27,6 +27,7 @@ end)
 unified_inventory.register_button("armor", {
 	type = "image",
 	image = "inventory_plus_armor.png",
+	tooltip = S("3d Armor")
 })
 
 unified_inventory.register_page("armor", {

--- a/3d_armor_ui/init.lua
+++ b/3d_armor_ui/init.lua
@@ -1,16 +1,10 @@
+-- support for i18n
+local S = armor_i18n.gettext
+local F = armor_i18n.fgettext
+
 if not minetest.global_exists("unified_inventory") then
-	minetest.log("warning", "3d_armor_ui: Mod loaded but unused.")
+	minetest.log("warning", S("3d_armor_ui: Mod loaded but unused."))
 	return
-end
-local S = function(s) return s end
-if minetest.global_exists("intllib") then
-	if intllib.make_gettext_pair then
-		-- New method using gettext.
-		S = intllib.make_gettext_pair()
-	else
-		-- Old method using text files.
-		S = intllib.Getter()
-	end
 end
 
 if unified_inventory.sfinv_compat_layer then
@@ -35,23 +29,23 @@ unified_inventory.register_page("armor", {
 		local fy = perplayer_formspec.formspec_y
 		local name = player:get_player_name()
 		if armor.def[name].init_time == 0 then
-			return {formspec="label[0,0;Armor not initialized!]"}
+			return {formspec="label[0,0;"..F("Armor not initialized!").."]"}
 		end
 		local formspec = "background[0.06,"..fy..";7.92,7.52;3d_armor_ui_form.png]"..
-			"label[0,0;Armor]"..
+			"label[0,0;"..F("Armor").."]"..
 			"list[detached:"..name.."_armor;armor;0,"..fy..";2,3;]"..
 			"image[2.5,"..(fy - 0.25)..";2,4;"..armor.textures[name].preview.."]"..
-			"label[5.0,"..(fy + 0.0)..";"..S("Level")..": "..armor.def[name].level.."]"..
-			"label[5.0,"..(fy + 0.5)..";"..S("Heal")..":  "..armor.def[name].heal.."]"..
+			"label[5.0,"..(fy + 0.0)..";"..F("Level")..": "..armor.def[name].level.."]"..
+			"label[5.0,"..(fy + 0.5)..";"..F("Heal")..":  "..armor.def[name].heal.."]"..
 			"listring[current_player;main]"..
 			"listring[detached:"..name.."_armor;armor]"
 		if armor.config.fire_protect then
 			formspec = formspec.."label[5.0,"..(fy + 1.0)..";"..
-				S("Fire")..":  "..armor.def[name].fire.."]"
+				F("Fire")..":  "..armor.def[name].fire.."]"
 		end
 		if minetest.global_exists("technic") then
 			formspec = formspec.."label[5.0,"..(fy + 1.5)..";"..
-				S("Radiation")..":  "..armor.def[name].groups["radiation"].."]"
+				F("Radiation")..":  "..armor.def[name].groups["radiation"].."]"
 		end
 		return {formspec=formspec}
 	end,

--- a/hazmat_suit/init.lua
+++ b/hazmat_suit/init.lua
@@ -1,16 +1,9 @@
+-- support for i18n
+local S = armor_i18n.gettext
+
 if not minetest.get_modpath("technic") then
-	minetest.log("warning", "hazmat_suit: Mod loaded but unused.")
+	minetest.log("warning", S("hazmat_suit: Mod loaded but unused."))
 	return
-end
-local S = function(s) return s end
-if minetest.global_exists("intllib") then
-	if intllib.make_gettext_pair then
-		-- New method using gettext.
-		S = intllib.make_gettext_pair()
-	else
-		-- Old method using text files.
-		S = intllib.Getter()
-	end
 end
 
 minetest.register_craftitem("hazmat_suit:helmet_hazmat", {

--- a/shields/init.lua
+++ b/shields/init.lua
@@ -1,13 +1,6 @@
-local S = function(s) return s end
-if minetest.global_exists("intllib") then
-	if intllib.make_gettext_pair then
-		-- New method using gettext.
-		S = intllib.make_gettext_pair()
-	else
-		-- Old method using text files.
-		S = intllib.Getter()
-	end
-end
+-- support for i18n
+local S = armor_i18n.gettext
+
 local use_moreores = minetest.get_modpath("moreores")
 local function play_sound_effect(player, name)
 	if player then

--- a/technic_armor/init.lua
+++ b/technic_armor/init.lua
@@ -1,16 +1,10 @@
+-- support for i18n
+local S = armor_i18n.gettext
+local F = armor_i18n.fgettext
+
 if not minetest.get_modpath("technic_worldgen") then
-	minetest.log("warning", "technic_armor: Mod loaded but unused.")
+	minetest.log("warning", S("technic_armor: Mod loaded but unused."))
 	return
-end
-local S = function(s) return s end
-if minetest.global_exists("intllib") then
-	if intllib.make_gettext_pair then
-		-- New method using gettext.
-		S = intllib.make_gettext_pair()
-	else
-		-- Old method using text files.
-		S = intllib.Getter()
-	end
 end
 
 local stats = {
@@ -58,7 +52,8 @@ for key, armor in pairs(stats) do
 	for partkey, part in pairs(parts) do
 		local partname = "technic_armor:"..partkey.."_"..key
 		minetest.register_tool(partname, {
-			description = armor.name.." "..part.name,
+			-- Translators: @1 stands for material and @2 for part of the armor, so that you could use a conjunction if in your language part name comes first then material (e.g. in french 'Silver Boots' is translated in 'Bottes en argent' by using '@2 en @1' as translated string)
+			description = S("@1 @2", armor.name, part.name),
 			inventory_image = "technic_armor_inv_"..partkey.."_"..key..".png",
 			groups = {["armor_"..part.place]=math.floor(part.level*armor.armor), armor_heal=armor.heal, armor_use=armor.use, armor_radiation=math.floor(part.radlevel*armor.radiation)},
 			wear = 0,


### PR DESCRIPTION
I've seen that intllib was partially supported (without lcale files) so I've upgraded to the latest boilerplate in 3d_armor mod.
There is a script to update pot template and po files in tools folder, it takes care of all mods included in 3d_armor modpack folder.

Removed optional dependecy to intllib for mods others than 3d_armor.
Added S function (standard gettext) and F function (gettext with minetest.formspec_escape) for strings in formspec. Only required ones are locally defined in *.lua files.

Hope it could be useful.

Ps : I've also added a translatable tooltip for unified inventory