### PR TITLE
Change armor stand recipe to use any item from the fence group.

### DIFF
--- a/3d_armor_stand/init.lua
+++ b/3d_armor_stand/init.lua
@@ -324,8 +324,8 @@ minetest.register_entity("3d_armor_stand:armor_entity", {
 minetest.register_craft({
 	output = "3d_armor_stand:armor_stand",
 	recipe = {
-		{"", "default:fence_wood", ""},
-		{"", "default:fence_wood", ""},
+		{"", "group:fence", ""},
+		{"", "group:fence", ""},
 		{"default:steel_ingot", "default:steel_ingot", "default:steel_ingot"},
 	}
 })


### PR DESCRIPTION
I found it strange that I could only craft armor stands with the standard fence from the default mod and not other kinds of fences so this changes the recipe to use any item from the fence group. This has the side effect of allowing using fence gates too, but I don't think that really matters.