### PR TITLE
Auto-refresh armor stands after clearobjects.

### DIFF
--- a/3d_armor_stand/init.lua
+++ b/3d_armor_stand/init.lua
@@ -321,6 +321,18 @@ minetest.register_entity("3d_armor_stand:armor_entity", {
 	end,
 })
 
+minetest.register_abm({
+	nodenames = {"3d_armor_stand:locked_armor_stand", "3d_armor_stand:armor_stand"},
+	interval = 15,
+	chance = 1,
+	action = function(pos, node, active_object_count, active_object_count_wider)
+		local num
+		num = #minetest.get_objects_inside_radius(pos, 0.5)
+		if num > 0 then return end
+		update_entity(pos)
+	end
+})
+
 minetest.register_craft({
 	output = "3d_armor_stand:armor_stand",
 	recipe = {


### PR DESCRIPTION
Currently armor stands appear empty after a clearobjects, in order to refresh them the armor must be removed and put back on again, this code automatically refreshes armor stands periodically to avoid these issues.