### PR TITLE
Fix Armor Stand textures used for armor definitions with explicit "texture" attribute

### DIFF
--- a/3d_armor_stand/init.lua
+++ b/3d_armor_stand/init.lua
@@ -75,11 +75,11 @@ local function update_entity(pos)
 					local def = stack:get_definition() or {}
 					local groups = def.groups or {}
 					if groups["armor_"..element] then
-                        if def.texture then
-                            table.insert(textures, def.texture)
+						if def.texture then
+							table.insert(textures, def.texture)
 						else
-    						table.insert(textures, item:gsub("%:", "_")..".png")
-                        end
+							table.insert(textures, item:gsub("%:", "_")..".png")
+						end
 					end
 				end
 			end


### PR DESCRIPTION
The Armor Stand would fail showing armor that has a specific "texture" attribute in its definition -- it would append an extra ".png" to the texture filename (i.e. try to use "mymod_myboots **.png.png** ")

This change fixes it so both implicitly textured armor and explicitly textured armor both display correctly on Armor Stands.