### PR TITLE
Disbale armor drop when dying in creative mode.

### DIFF
--- a/3d_armor/init.lua
+++ b/3d_armor/init.lua
@@ -315,6 +315,10 @@ if armor.config.drop == true or armor.config.destroy == true then
 		if not name then
 			return
 		end
+		if creative and creative.is_enabled_for and creative.is_enabled_for(name) then 
+			return
+		end
+		
 		local drop = {}
 		for i=1, armor_inv:get_size("armor") do
 			local stack = armor_inv:get_stack("armor", i)


### PR DESCRIPTION
In creative mode, inventory is usually not dropped upon player death.  This change extends this behavior to armor.