### PR TITLE
make fire protect a default option

### DIFF
--- a/3d_armor/api.lua
+++ b/3d_armor/api.lua
@@ -95,7 +95,7 @@ armor.config = {
 	material_mithril = true,
 	material_crystal = true,
 	water_protect = true,
-	fire_protect = minetest.get_modpath("ethereal") ~= nil,
+	fire_protect = true,
 	punch_damage = true,
 }
 

--- a/3d_armor/api.lua
+++ b/3d_armor/api.lua
@@ -95,7 +95,7 @@ armor.config = {
 	material_mithril = true,
 	material_crystal = true,
 	water_protect = true,
-	fire_protect = true,
+	fire_protect = minetest.get_modpath("ethereal") ~= nil or minetest.get_modpath("terumet") ~= nil,
 	punch_damage = true,
 }
 

--- a/3d_armor/init.lua
+++ b/3d_armor/init.lua
@@ -446,10 +446,12 @@ if armor.config.water_protect == true or armor.config.fire_protect == true then
 				local node_head = minetest.get_node(pos).name
 				pos.y = pos.y - 1.2 -- feet level
 				local node_feet = minetest.get_node(pos).name
+				pos.y = pos.y - 1 -- below level
+				local node_below = minetest.get_node(pos).name
 				-- is player inside a hot node?
 				for _, row in pairs(armor.fire_nodes) do
 					-- check fire protection, if not enough then get hurt
-					if row[1] == node_head or row[1] == node_feet then
+					if row[1] == node_head or row[1] == node_feet or row[1] == node_below then
 						if fire_damage == true then
 							armor:punch(player, "fire")
 							last_punch_time[name] = minetest.get_gametime()


### PR DESCRIPTION
This PR is more of a question. 

It seems that the major reason that fire protection isn't enabled by default is because when it is, 3d_armor entirely overrides the calculation of fire damage, and fire damage is only calculated for a hard-coded list of nodes. 

However, I'm working with Terumoc on the terumet mod (https://github.com/terumoc/terumet) (well, Terumoc is doing most of the work), and we're discussing the most sensible way to add fire protection to the armor in that mod. One option, of course, is just to ask server owners to create a setting to enable fire protection. Another is to change the default - but this makes it so that torches damage players by default, and possibly misses other fire damage nodes added by arbitrary mods. A third option is to add terumet to the mods in which fire protection is enabled by default. 

I'm wondering if you, the mod maintainer, as any additional insight. Also, it seems like being able to add/remove nodes as sources of fire damage should be part of the 3d_armor API. I can add that to this PR if desired.