### PR TITLE
Use newer functions from MT/MTG 5.0.0+

### DIFF
--- a/.github/pull.yml
+++ b/.github/pull.yml
@@ -1,0 +1,5 @@
+version: "1"
+rules:
+  - base: update_integration_test
+    upstream: minetest-mods:master
+    mergeMethod: hardreset

--- a/3d_armor/api.lua
+++ b/3d_armor/api.lua
@@ -465,8 +465,9 @@ end
 
 armor.load_armor_inventory = function(self, player)
 	local _, inv = self:get_valid_player(player, "[load_armor_inventory]")
+	local meta = player:get_meta()
 	if inv then
-		local armor_list_string = player:get_attribute("3d_armor_inventory")
+		local armor_list_string = meta:get_string("3d_armor_inventory")
 		if armor_list_string then
 			inv:set_list("armor",
 				self:deserialize_inventory_list(armor_list_string))
@@ -477,8 +478,9 @@ end
 
 armor.save_armor_inventory = function(self, player)
 	local _, inv = self:get_valid_player(player, "[save_armor_inventory]")
+	local meta = player:get_meta()	
 	if inv then
-		player:set_attribute("3d_armor_inventory",
+		meta:set_string("3d_armor_inventory",
 			self:serialize_inventory_list(inv:get_list("armor")))
 	end
 end
@@ -519,7 +521,7 @@ armor.drop_armor = function(pos, stack)
 	if node then
 		local obj = minetest.add_item(pos, stack)
 		if obj then
-			obj:setvelocity({x=math.random(-1, 1), y=5, z=math.random(-1, 1)})
+			obj:set_velocity({x=math.random(-1, 1), y=5, z=math.random(-1, 1)})
 		end
 	end
 end

--- a/3d_armor/api.lua
+++ b/3d_armor/api.lua
@@ -465,8 +465,8 @@ end
 
 armor.load_armor_inventory = function(self, player)
 	local _, inv = self:get_valid_player(player, "[load_armor_inventory]")
-	local meta = player:get_meta()
 	if inv then
+		local meta = player:get_meta()
 		local armor_list_string = meta:get_string("3d_armor_inventory")
 		if armor_list_string then
 			inv:set_list("armor",
@@ -478,8 +478,8 @@ end
 
 armor.save_armor_inventory = function(self, player)
 	local _, inv = self:get_valid_player(player, "[save_armor_inventory]")
-	local meta = player:get_meta()	
 	if inv then
+		local meta = player:get_meta()
 		meta:set_string("3d_armor_inventory",
 			self:serialize_inventory_list(inv:get_list("armor")))
 	end

--- a/3d_armor/init.lua
+++ b/3d_armor/init.lua
@@ -114,7 +114,8 @@ local function validate_armor_inventory(player)
 		return
 	end
 	local armor_prev = {}
-	local armor_list_string = player:get_attribute("3d_armor_inventory")
+	local attribute_meta = player:get_meta() -- I know, the function's name is weird but let it be like that. ;)
+	local armor_list_string = attribute_meta:get_string("3d_armor_inventory")
 	if armor_list_string then
 		local armor_list = armor:deserialize_inventory_list(armor_list_string)
 		for i, stack in ipairs(armor_list) do
@@ -406,7 +407,7 @@ minetest.register_globalstep(function(dtime)
 	end
 end)
 
--- Fire Protection and water breating, added by TenPlus1
+-- Fire Protection and water breathing, added by TenPlus1.
 
 if armor.config.fire_protect == true then
 	-- override hot nodes so they do not hurt player anywhere but mod

--- a/3d_armor/mod.conf
+++ b/3d_armor/mod.conf
@@ -1,0 +1,4 @@
+name = 3d_armor
+depends = default
+optional_depends = player_monoids, armor_monoid, pova, fire, ethereal, bakedclay, intllib
+description = Adds craftable armor that is visible to other players.

--- a/3d_armor_ip/description.txt
+++ b/3d_armor_ip/description.txt
@@ -1,1 +1,1 @@
-Adds 3d_armor page to the inventory plus
+Adds 3d_armor page to the inventory plus.

--- a/3d_armor_ip/mod.conf
+++ b/3d_armor_ip/mod.conf
@@ -1,0 +1,4 @@
+name = 3d_armor_ip
+depends = 3d_armor
+optional_depends = inventory_plus
+description = Adds 3d_armor page to the inventory plus.

--- a/3d_armor_sfinv/description.txt
+++ b/3d_armor_sfinv/description.txt
@@ -1,1 +1,1 @@
-Adds 3d_armor page to the sfinv inventory
+Adds 3d_armor page to the sfinv inventory.

--- a/3d_armor_sfinv/mod.conf
+++ b/3d_armor_sfinv/mod.conf
@@ -1,0 +1,4 @@
+name = 3d_armor_sfinv
+depends = 3d_armor
+optional_depends = sfinv
+description = Adds 3d_armor page to the sfinv inventory.

--- a/3d_armor_stand/init.lua
+++ b/3d_armor_stand/init.lua
@@ -97,7 +97,7 @@ local function update_entity(pos)
 				yaw = math.pi / 2
 			end
 		end
-		object:setyaw(yaw)
+		object:set_yaw(yaw)
 		object:set_properties({textures={texture}})
 	end
 end

--- a/3d_armor_stand/mod.conf
+++ b/3d_armor_stand/mod.conf
@@ -1,0 +1,2 @@
+name = 3d_armor_stand
+depends = 3d_armor

--- a/3d_armor_ui/description.txt
+++ b/3d_armor_ui/description.txt
@@ -1,1 +1,1 @@
-Adds 3d_armor page to the unified inventory
+Adds 3d_armor page to the unified inventory.

--- a/3d_armor_ui/mod.conf
+++ b/3d_armor_ui/mod.conf
@@ -1,0 +1,4 @@
+name = 3d_armor_ui
+depends = 3d_armor
+optional_depends = unified_inventory
+description = Adds 3d_armor page to the unified inventory.

--- a/modpack.conf
+++ b/modpack.conf
@@ -1,0 +1,2 @@
+name = minetest-3d_armor
+description = Visible player armor & wielded items.

--- a/shields/mod.conf
+++ b/shields/mod.conf
@@ -1,0 +1,3 @@
+name = shields
+depends = default, 3d_armor
+description = Adds visible shields to 3d armor.

--- a/wieldview/mod.conf
+++ b/wieldview/mod.conf
@@ -1,0 +1,3 @@
+name = wieldview
+depends = 3d_armor
+description = Makes hand wielded items visible to other players.


### PR DESCRIPTION
Compatibility with MT 5.0.0 and above:

- Replace deprecated functions with newer ones.
- Store armor on player metadata.
- Use `mod(pack).conf` for dependencies and description.

Tested with MT/MTG 5.0.1, works.
This will break compatibility with MT 0.4.17.1 and below.