### PR TITLE
Preserve immortal group for per-player damage

### DIFF
--- a/3d_armor/api.lua
+++ b/3d_armor/api.lua
@@ -279,6 +279,11 @@ armor.set_player_armor = function(self, player)
 	if use_armor_monoid then
 		armor_monoid.monoid:add_change(player, change, "3d_armor:armor")
 	else
+		-- Preserve immortal group (damage disabled for player)
+		local immortal = player:get_armor_groups().immortal
+		if immortal and immortal ~= 0 then
+			groups.immortal = 1
+		end
 		player:set_armor_groups(groups)
 	end
 	if use_player_monoids then


### PR DESCRIPTION
Per-player damage control is almost possible in late 5.1.0-dev, but 3d_armor overrides this group.
Fixes https://github.com/minetest/minetest/issues/9022


## This mod is outdated. Updates can be found here:
### -> https://github.com/minetest-mods/3d_armor